### PR TITLE
Support most in-service Python versions.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,12 @@ jobs:
   tests:
     if: github.event.action != 'closed' || github.event.pull_request.merged
 
+    name: Test Python ${{ matrix.python_version }}
     runs-on: ubuntu-latest
-
+    strategy:
+      max-parallel: 4
+      matrix:
+        python_version: ['3.5', '3.6', '3.7', '3.8']
     env:
       PYTHONDEVMODE: 1
 
@@ -21,7 +25,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: ${{ matrix.python_version }}
 
     - name: Poetry setup
       run: |
@@ -31,17 +35,19 @@ jobs:
       run: |
         poetry install
 
+    - name: Lint with mypy
+      run: |
+        poetry run mypy mousebender
+  
+    - name: Check format with Black
+      if: matrix.python_version!='3.5'
+      run: |
+        poetry run black --check .
+
     - name: Test with pytest
       run: |
         poetry run pytest --cov
 
-    - name: Lint with mypy
-      run: |
-        poetry run mypy mousebender
-
-    - name: Check format with Black
-      run: |
-        poetry run black --check .
 
 
   release:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,8 @@ jobs:
     name: Test Python ${{ matrix.python_version }}
     runs-on: ubuntu-latest
     strategy:
-      max-parallel: 4
       matrix:
-        python_version: ['3.5', '3.6', '3.7', '3.8']
+        python_version: ['3.6', '3.7', '3.8']
     env:
       PYTHONDEVMODE: 1
 
@@ -40,7 +39,6 @@ jobs:
         poetry run mypy mousebender
   
     - name: Check format with Black
-      if: matrix.python_version!='3.5'
       run: |
         poetry run black --check .
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Lint with mypy
       run: |
         poetry run mypy mousebender
-  
+
     - name: Check format with Black
       run: |
         poetry run black --check .

--- a/mousebender/simple.py
+++ b/mousebender/simple.py
@@ -6,6 +6,7 @@ import re
 from typing import Optional, Tuple
 import urllib.parse
 
+import attr
 import packaging.specifiers
 
 
@@ -88,15 +89,20 @@ def parse_repo_index(html):
     return parser.mapping
 
 
+@attr.s
 class ArchiveLink:
 
     """Data related to a link to an archive file."""
 
-    filename = ""
-    url = ""
-    requires_python = packaging.specifiers.parse("0.0")
-    hash_ = None
-    gpg_sig = None
+    def __eq__(self, other):
+        return (
+            isinstance(other, ArchiveLink)
+            and self.filename == other.filename
+            and self.url == other.url
+            and self.requires_python == other.requires_python
+            and self.hash_ == other.hash_
+            and self.gpg_sig == other.gpg_sig
+        )
 
     def __init__(
         self,
@@ -111,16 +117,6 @@ class ArchiveLink:
         self.requires_python = requires_python
         self.hash_ = hash
         self.gpg_sig = gpg_sig
-
-    def __eq__(self, other):
-        return (
-            isinstance(other, ArchiveLink)
-            and self.filename == other.filename
-            and self.url == other.url
-            and self.requires_python == other.requires_python
-            and self.hash_ == other.hash_
-            and self.gpg_sig == other.gpg_sig
-        )
 
 
 class _ArchiveLinkHTMLParser(html.parser.HTMLParser):

--- a/mousebender/simple.py
+++ b/mousebender/simple.py
@@ -1,14 +1,12 @@
 """Parsing for PEP 503 -- Simple Repository API."""
-import collections
 import html
 import html.parser
 import re
-from typing import Optional, Tuple
 import urllib.parse
+from typing import Optional, Tuple
 
 import attr
 import packaging.specifiers
-
 
 _NORMALIZE_RE = re.compile(r"[-_.]+")
 
@@ -89,7 +87,7 @@ def parse_repo_index(html):
     return parser.mapping
 
 
-@attr.s
+@attr.s(frozen=True)
 class ArchiveLink:
 
     """Data related to a link to an archive file."""

--- a/mousebender/simple.py
+++ b/mousebender/simple.py
@@ -94,29 +94,12 @@ class ArchiveLink:
 
     """Data related to a link to an archive file."""
 
-    def __eq__(self, other):
-        return (
-            isinstance(other, ArchiveLink)
-            and self.filename == other.filename
-            and self.url == other.url
-            and self.requires_python == other.requires_python
-            and self.hash_ == other.hash_
-            and self.gpg_sig == other.gpg_sig
-        )
-
-    def __init__(
-        self,
-        filename: str,
-        url: str,
-        requires_python: packaging.specifiers.SpecifierSet,
-        hash: Optional[Tuple[str, str]] = None,
-        gpg_sig: Optional[bool] = None,
-    ):
-        self.filename = filename
-        self.url = url
-        self.requires_python = requires_python
-        self.hash_ = hash
-        self.gpg_sig = gpg_sig
+    filename: str = attr.ib()
+    url: str = attr.ib()
+    requires_python: packaging.specifiers.SpecifierSet = attr.ib()
+    hash_: Optional[Tuple[str, str]] = attr.ib(default=None)
+    gpg_sig: Optional[bool] = attr.ib(default=None)
+    # yanked: Tuple[bool, str] = attr.ib(default=(False, ""))
 
 
 class _ArchiveLinkHTMLParser(html.parser.HTMLParser):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,6 @@ classifiers = ["Topic :: Software Development :: Libraries :: Python Modules"]
 python = ">=3.6,<4"
 packaging = "^20.3"
 attrs = "^19.3.0"
-importlib-resources = "^1.4.0"
 
 [tool.poetry.dev-dependencies]
 mypy = "^0.770"
@@ -26,6 +25,7 @@ pytest-cov = "^2.8.1"
 docopt = "^0.6.2"
 black = "^19.10b0"
 twine = "^3.1.1"
+importlib-resources = "^1.5.0"
 
 [tool.poetry.urls]
 "issues" = "https://github.com/brettcannon/mousebender/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,17 +13,17 @@ classifiers = ["Topic :: Software Development :: Libraries :: Python Modules"]
 
 [tool.poetry.dependencies]
 # The `<4` restriction is because of coverage.py.
-python = ">=3.8,<4"
+python = ">=3.5.9,<4"
 packaging = "^20.3"
 
 [tool.poetry.dev-dependencies]
 mypy = "^0.770"
-black = "^19.10b0"
 coverage = {extras = ["toml"], version = "^5.0.4"}
 pytest = "^5.4.1"
 pytest-cov = "^2.8.1"
 docopt = "^0.6.2"
-twine = "^3.1.1"
+black = {version = "^19.10b0", python = ">=3.6"}
+twine = {version = "^3.1.1", python = ">=3.6"}
 
 [tool.poetry.urls]
 "issues" = "https://github.com/brettcannon/mousebender/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,10 @@ classifiers = ["Topic :: Software Development :: Libraries :: Python Modules"]
 
 [tool.poetry.dependencies]
 # The `<4` restriction is because of coverage.py.
-python = ">=3.5.9,<4"
+python = ">=3.6,<4"
 packaging = "^20.3"
+attrs = "^19.3.0"
+importlib-resources = "^1.4.0"
 
 [tool.poetry.dev-dependencies]
 mypy = "^0.770"
@@ -22,8 +24,8 @@ coverage = {extras = ["toml"], version = "^5.0.4"}
 pytest = "^5.4.1"
 pytest-cov = "^2.8.1"
 docopt = "^0.6.2"
-black = {version = "^19.10b0", python = ">=3.6"}
-twine = {version = "^3.1.1", python = ">=3.6"}
+black = "^19.10b0"
+twine = "^3.1.1"
 
 [tool.poetry.urls]
 "issues" = "https://github.com/brettcannon/mousebender/issues"

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -1,6 +1,5 @@
 """Tests for mousebender.simple."""
 import importlib_resources
-
 import packaging.version
 import pytest
 


### PR DESCRIPTION
Fix for #20

This change:
- Provides support for Python versions ~3.5+~ 3.6+.
- Updates dependencies based on version.
- Runs a matrix of Python versions in CI testing.
- Removes Python syntax and functionality not supported in earlier versions.
- Fully maintains testing & coverage.