### PR TITLE
Create convenient indexed structure into archive_links after parsing

### DIFF
--- a/mousebender/simple.py
+++ b/mousebender/simple.py
@@ -142,6 +142,7 @@ class ArchiveLink:
 class _ArchiveLinkHTMLParser(html.parser.HTMLParser):
     def __init__(self):
         self.archive_links = []
+        # From the description in the issue, here's the structure proposed:
         self.index: Dict[
             str,  # Project
             Dict[
@@ -152,6 +153,9 @@ class _ArchiveLinkHTMLParser(html.parser.HTMLParser):
                 ],
             ],
         ] = {}
+        # ... however, I don't uet see the build number in here, and I'm missing what
+        # the Tuple at the end is for. (None, {Tag: ArchiveLink}) is valid, as is (ArchiveLink, None),
+        # as is (None, None) and (ArchiveLink, {Tag: ArchiveLink}).
         super().__init__()
 
     def handle_starttag(self, tag, attrs_list):

--- a/mousebender/simple.py
+++ b/mousebender/simple.py
@@ -227,7 +227,7 @@ class _ArchiveLinkHTMLParser(html.parser.HTMLParser):
                 # and re-create it:
                 self.index[proj][ver] = (sdist_lnk, archive_link_dict)
 
-        except packaging.utils.InvalidWheelFilename as bad_file_name:
+        except packaging.utils.InvalidWheelFilename:
             # This is either an sdist or something else.
 
             try:
@@ -237,7 +237,7 @@ class _ArchiveLinkHTMLParser(html.parser.HTMLParser):
                 if ver not in self.index[proj]:
                     self.index[proj][ver] = (archive, {})
 
-            except packaging.utils.InvalidSdistFilename as bad_file_name:
+            except packaging.utils.InvalidSdistFilename:
                 pass
                 # warnings.warn(
                 #     f"File {archive.filename} is not a valid wheel nor a valid sdist name, according to `packages`. Skipping."

--- a/mousebender/simple.py
+++ b/mousebender/simple.py
@@ -5,10 +5,11 @@ import re
 import urllib.parse
 import warnings
 
-from typing import Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 import attr
 import packaging.specifiers
+import packaging.tags
 
 _NORMALIZE_RE = re.compile(r"[-_.]+")
 
@@ -141,6 +142,16 @@ class ArchiveLink:
 class _ArchiveLinkHTMLParser(html.parser.HTMLParser):
     def __init__(self):
         self.archive_links = []
+        self.index: Dict[
+            str,  # Project
+            Dict[
+                str,  # Version
+                Tuple[
+                    Optional[ArchiveLink],
+                    Optional[Dict[packaging.tags.Tag, ArchiveLink]],  # Tag
+                ],
+            ],
+        ] = {}
         super().__init__()
 
     def handle_starttag(self, tag, attrs_list):
@@ -187,6 +198,11 @@ class _ArchiveLinkHTMLParser(html.parser.HTMLParser):
         self.archive_links.append(
             ArchiveLink(filename, url, requires_python, hash_, gpg_sig, yanked)
         )
+
+    def update_index(self, archive: ArchiveLink):
+        # Dict[str, Dict[str, Tuple[Optional[ArchiveLink], Optional[Dict[Tag, ArchiveLink]]]]]
+        proj, ver, *_ = archive.filename.partition("-")
+        self.index[proj]
 
 
 def parse_archive_links(html):

--- a/mousebender/simple.py
+++ b/mousebender/simple.py
@@ -1,12 +1,10 @@
 """Parsing for PEP 503 -- Simple Repository API."""
 import html
 import html.parser
-from msilib import sequence
 import re
 import urllib.parse
 import warnings
-
-from typing import Dict, FrozenSet, MutableSequence, Optional, Tuple
+from typing import Dict, FrozenSet, Optional, Tuple
 
 import attr
 import packaging.specifiers

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -5,7 +5,6 @@ import importlib_resources
 import packaging.tags
 import packaging.version
 import pytest
-
 from mousebender import simple
 
 from .data import simple as simple_data


### PR DESCRIPTION
Fix for #48 

_DRAFT: Looking for early feedback after some changes have been implemented._

Add a convenient struct to search through archive_links via project, version, tag.

Note: `build_number` is still a bit of a grey area with this change!